### PR TITLE
load the 4.1 api version of webkit

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ It is implemented in *Python3* and uses *Glib GObject Introspection* to use *Gtk
 - *Python3*
 - *Glib GObject Introspection*
   - *Gtk3*
-  - *WebKit2*
+  - *WebKit2Gtk-4.1*
 - *Paho MQTT*
 
 ## Installation

--- a/src/barkery
+++ b/src/barkery
@@ -42,7 +42,7 @@ setproctitle("barkery")
 gi.require_version('Gtk', '3.0')
 
 # load Webkit2
-gi.require_version('WebKit2', '4.0')
+gi.require_version('WebKit2', '4.1')
 
 from gi.repository import WebKit2
 from gi.repository import Gdk


### PR DESCRIPTION
this is the new api version of webkit that uses libsoup3 instead of libsoup2.4. the latter is deprecated, so the preferred default webkit is 4.1 over 4.0 (no program change if not also using libsoup apis directly)